### PR TITLE
Instagram added an id field for videos.

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -28,7 +28,7 @@ class ApiModel(object):
 
 class Image(ApiModel):
 
-    def __init__(self, url, width, height):
+    def __init__(self, url, width, height, **kwargs):
         self.url = url
         self.height = height
         self.width = width

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="python-instagram",
-      version="1.3.2.1",
+      version="1.3.2.2",
       description="Instagram API client",
       license="MIT",
       install_requires=["simplejson","httplib2","six"],


### PR DESCRIPTION
https://github.com/facebookarchive/python-instagram/pull/256
https://github.com/wkoot/python-instagram/pull/14

It has been causing errors like below:
> psp-app1 PhotoContestPulling 2017-10-13 03:30:02,848 11001 140111869425408 ERROR 
PhotoContestPulling Failed pulling instagram media against hashtag myrecipe for campaigns [<Coupons.Coupons object at 0x3fca250>]
Traceback (most recent call last):
  File "/home/offerpop-app/releases/20171005151209/Scripts/../Engine/offerpop/jobs/PhotoContestPulling.py", line 44, in pull_instagram_media
    recent_media, pagination = api.tag_recent_media(tag_name=hashtag)
  File "/opt/offerpop/python/lib/python2.7/site-packages/instagram/bind.py", line 197, in _call
    return method.execute()
  File "/opt/offerpop/python/lib/python2.7/site-packages/instagram/bind.py", line 189, in execute
    content, next = self._do_api_request(url, method, body, headers)
  File "/opt/offerpop/python/lib/python2.7/site-packages/instagram/bind.py", line 151, in _do_api_request
    obj = self.root_class.object_from_dictionary(entry)
  File "/opt/offerpop/python/lib/python2.7/site-packages/instagram/models.py", line 87, in object_from_dictionary
    new_media.videos[version] = Video.object_from_dictionary(version_info)
  File "/opt/offerpop/python/lib/python2.7/site-packages/instagram/models.py", line 13, in object_from_dictionary
    return cls(**entry_str_dict)
    TypeError: __init__() got an unexpected keyword argument 'id'